### PR TITLE
Tinkers Construct Compat Fix

### DIFF
--- a/src/main/java/net/sdm/recipemachinestage/mixin/integration/tinkers_construct/PartBuilderBlockEntityMixin.java
+++ b/src/main/java/net/sdm/recipemachinestage/mixin/integration/tinkers_construct/PartBuilderBlockEntityMixin.java
@@ -54,10 +54,8 @@ public abstract class PartBuilderBlockEntityMixin {
                     newRecipes.put(entry.getKey(), entry.getValue());
                 }
             }
+            cir.setReturnValue(newRecipes);
         }
-
-        cir.setReturnValue(newRecipes);
-
     }
 
     @Inject(method = "getPartRecipe", at = @At("RETURN"), cancellable = true)


### PR DESCRIPTION
Fixes: {[#11](https://github.com/DeusSixik/Recipe-Machine-Stage/issues/11)}

`thisEntity.getLevel().getServer()` returns null on a ClientBound packet as ClientLevel doesn't have a Server