### PR TITLE
fix: migrate AStages integration to 2.x API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ dependencies {
     implementation fg.deobf("curse.maven:rhino-416294:5655836")
     implementation fg.deobf("curse.maven:architectury-api-419699:5137938")
 
-    implementation fg.deobf("curse.maven:astages-1120180:6440354")
+    implementation fg.deobf("curse.maven:astages-1120180:8292440")
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 

--- a/src/main/java/net/sdm/recipemachinestage/api/stage/compat/AStagesStage.java
+++ b/src/main/java/net/sdm/recipemachinestage/api/stage/compat/AStagesStage.java
@@ -1,9 +1,10 @@
 package net.sdm.recipemachinestage.api.stage.compat;
 
-import com.alessandro.astages.capability.ClientPlayerStage;
-import com.alessandro.astages.event.custom.ClientSynchronizeStagesEvent;
-import com.alessandro.astages.event.custom.actions.StageAddedPlayerEvent;
-import com.alessandro.astages.event.custom.actions.StageRemovedPlayerEvent;
+import com.alessandro.astages.api.event.player.StageAddedPlayerEvent;
+import com.alessandro.astages.api.event.player.StageRemovedPlayerEvent;
+import com.alessandro.astages.api.event.sync.ClientSynchronizeStagesEvent;
+import com.alessandro.astages.api.holder.AClientHolder;
+import com.alessandro.astages.api.util.AStagesClientUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -20,13 +21,13 @@ public class AStagesStage implements IStage {
     @Override
     @OnlyIn(Dist.CLIENT)
     public Collection<String> getStages() {
-        return ClientPlayerStage.getPlayerStages();
+        return AStagesClientUtils.getStages(AClientHolder.serverAndPlayer());
     }
 
     @Override
     @OnlyIn(Dist.CLIENT)
     public boolean hasStage(String stage) {
-        return ClientPlayerStage.getPlayerStages().contains(stage);
+        return AStagesClientUtils.hasStage(AClientHolder.serverAndPlayer(), stage);
     }
 
     @Override
@@ -51,10 +52,10 @@ public class AStagesStage implements IStage {
     }
 
     protected void OnAdd(StageAddedPlayerEvent event) {
-        PlayerHelper.UpdateData(event.getEntity());
+        PlayerHelper.UpdateData(event.getPlayer());
     }
 
     protected void OnRemove(StageRemovedPlayerEvent event) {
-        PlayerHelper.UpdateData(event.getEntity());
+        PlayerHelper.UpdateData(event.getPlayer());
     }
 }

--- a/src/main/java/net/sdm/recipemachinestage/utils/PlayerHelper.java
+++ b/src/main/java/net/sdm/recipemachinestage/utils/PlayerHelper.java
@@ -1,7 +1,7 @@
 package net.sdm.recipemachinestage.utils;
 
-import com.alessandro.astages.capability.PlayerStageProvider;
-import com.alessandro.astages.util.AStagesUtil;
+import com.alessandro.astages.api.holder.AHolder;
+import com.alessandro.astages.api.util.AStagesUtils;
 import dev.latvian.mods.kubejs.integration.forge.gamestages.GameStagesWrapper;
 import net.darkhax.gamestages.GameStageHelper;
 import net.minecraft.nbt.*;
@@ -31,7 +31,16 @@ public class PlayerHelper {
     @Nullable
     public static RMSStagePlayerData getPlayerByGameProfile(MinecraftServer server, UUID id){
         var player = server.getPlayerList().getPlayer(id);
-        if(player == null) return PLAYER_DATA.getOrDefault(id, null);
+        if(player == null) {
+            RMSStagePlayerData stagePlayerData = PLAYER_DATA.getOrDefault(id, null);
+
+            if(ModList.get().isLoaded("astages") && stagePlayerData != null) {
+                stagePlayerData.addStage(AStagesUtils.getStages(AHolder.player(id)));
+                stagePlayerData.addStage(AStagesUtils.getStages(AHolder.server()));
+            }
+
+            return stagePlayerData;
+        }
 
         RMSStagePlayerData stagePlayerData = new RMSStagePlayerData();
 
@@ -42,9 +51,7 @@ public class PlayerHelper {
             stagePlayerData.addStage(GameStagesWrapper.get(player).getAll());
         }
         if(ModList.get().isLoaded("astages")) {
-            player.getCapability(PlayerStageProvider.PLAYER_STAGE).ifPresent(s -> {
-                stagePlayerData.addStage(s.getStages());
-            });
+            stagePlayerData.addStage(AStagesUtils.getStages(AHolder.serverAndPlayer(player)));
         }
         PLAYER_DATA.put(id, stagePlayerData);
 
@@ -61,7 +68,7 @@ public class PlayerHelper {
             flag = GameStagesWrapper.get(player).has(stage);
         }
         if(ModList.get().isLoaded("astages") && !flag) {
-            flag = AStagesUtil.hasStage(player, stage);
+            flag = AStagesUtils.hasStage(AHolder.serverAndPlayer(player), stage);
         }
 
         return flag;
@@ -73,7 +80,11 @@ public class PlayerHelper {
         public List<String> stages = new ArrayList<>();
 
         public void addStage(Collection<String> stages) {
-            this.stages.addAll(stages);
+            for (String stage : stages) {
+                if (!this.stages.contains(stage)) {
+                    this.stages.add(stage);
+                }
+            }
         }
 
         public List<String> getStages() {
@@ -117,9 +128,7 @@ public class PlayerHelper {
             data.addStage(GameStagesWrapper.get(player).getAll());
         }
         if(ModList.get().isLoaded("astages")) {
-            player.getCapability(PlayerStageProvider.PLAYER_STAGE).ifPresent(playerStage -> {
-                data.addStage(playerStage.getStages());
-            });
+            data.addStage(AStagesUtils.getStages(AHolder.serverAndPlayer(player)));
         }
         PLAYER_DATA.put(player.getGameProfile().getId(), data);
         savePlayer(player.getGameProfile().getId(), player.server);


### PR DESCRIPTION
## Summary

Related to #25

This PR updates the 1.20.1 AStages integration to work with AStages 2.x, specifically AStages 2.2.0.

## Problem

With AStages 2.2.0 installed, Recipe Machine Stage 1.20.1 fails during startup because it still references old AStages classes such as:

```text
com.alessandro.astages.event.custom.actions.StageAddedPlayerEvent
com.alessandro.astages.event.custom.ClientSynchronizeStagesEvent
com.alessandro.astages.capability.PlayerStageProvider
com.alessandro.astages.util.AStagesUtil
```

These APIs were moved/reworked in AStages 2.x.

## Changes

- Updated AStages event imports to `com.alessandro.astages.api.event.*`
- Replaced old capability access with `AHolder` / `AStagesUtils`
- Updated client-side stage checks to use `AClientHolder` / `AStagesClientUtils`
- Replaced event `getEntity()` calls with `getPlayer()`
- Updated the AStages dependency to the AStages 2.2.0 CurseForge file

No mod version or build artifact changes are included.

## Testing

- Built successfully on the `1.20.1` branch with:

```bash
./gradlew build
```

- Verified the generated classes reference the new `com.alessandro.astages.api.*` package instead of the old AStages API classes.
